### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ tgrade keys add my-validator --recover --home /opt/validator/.tgrade
 
 Into the mnemonic(s) used for your tgrade address
 
-### Get the pre-genesis file ( No available now, you have to wait till announcement and new commit )
+### Get the pre-genesis file
 Get the genesis file and moved to the right location
 ```bash
 wget https://raw.githubusercontent.com/confio/public-testnets/main/dryrunnet/config/pre-genesis.json -O ~/opt/validator/.tgrade/config/genesis.json
@@ -102,7 +102,7 @@ tgrade gentx my-validator 0utgd 90000000utgd \
   --chain-id tgrade-dryrunnet \
   --home /opt/validator/.tgrade
 ```
-node-idm pubkey and home values are just examples, please change it accordingly to your system/validator
+node-id, pubkey and home values are just examples, please change it accordingly to your system/validator
 
 ### Upload your Gen_TX
 The above will create a gentx file. We are going to need it for the genesis collect.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Get the genesis file and moved to the right location
 ```bash
 wget https://raw.githubusercontent.com/confio/public-testnets/main/dryrunnet/config/pre-genesis.json -O ~/opt/validator/.tgrade/config/genesis.json
 ```
-( this will be the case the APP Home directory is /opt/validator/.tgrade , please change it accordingly to your system/validator)
+( this will be the case if the APP Home directory is /opt/validator/.tgrade , please change it accordingly to your system/validator)
 
 ### Setup the right parameters and values on the TOML files
 Please edit the `config/app.toml` and `config/config.toml` accordingly
@@ -130,16 +130,16 @@ Get the genesis file and moved to the right location
 ```bash
 wget https://raw.githubusercontent.com/confio/public-testnets/main/dryrunnet/config/genesis.json -O ~/.tgrade/config/genesis.json
 ```
-( this will be the case the APP Home directory is ~/.tgrade , please change it accordingly to your system/validator)
+( this will be the case if the APP Home directory is ~/.tgrade , please change it accordingly to your system/validator)
 
 ### Start the syncing
 There are different ways to manage the tgrade binary on your validator,
 1. Setting up such binary to be managed by systemd, or
 2. Open a tmux or screen session and run tgrade start
 
-The synstax is:
+The syntax is:
 ```bash
 tgrade start --rpc.laddr tcp://0.0.0.0:26657 --home /opt/validator/.tgrade
 ```
-( this will be the case the APP Home directory is /opt/validator/.tgrade , please change it accordingly to your system/validator)
+( this will be the case if the APP Home directory is /opt/validator/.tgrade , please change it accordingly to your system/validator)
 


### PR DESCRIPTION
- Comment about waiting is longer needed.
- typo 
- On line 105, pubkey is referenced in the comment but not used in the previous command, perhaps key_name was intended?